### PR TITLE
Zappi status (as text devices)

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -54,8 +54,9 @@ class BasePlugin:
 
     zappi_mode_texts = { 1: 'Fast', 2: 'Eco', 3: 'Eco++' }
     zappi_status_texts = { 1 : 'Waiting for export', 2 : 'DSR-Demand Side Response', 3: 'Diverting/Charging', 4: 'Boosting', 5: 'Charge Complete' }
-    charge_status_texts = { 'A' : 'EV disconnected', 'B1': 'EV connected', 'B2' : 'Waiting for EV', 'C1': 'EV ready to charge', 'C2': 'Charging', 'F': 'Fault restart' }
-    
+    charge_status_texts = { 'A' : 'EV disconnected', 'B1': 'EV connected', 'B2' : 'Waiting for EV', 'C1': 'EV ready to charge', 'C2': 'Charging', 'F': 'Fault / Restart' }
+    # Source - https://myenergi.info/open-energy-monitor-local-emoncms-t2192.html
+    # Or... rewrite to combine into a single display status, like this? - https://myenergi.info/how-to-tell-charge-complete-in-api-t1595.html#p13021
 
     def __init__(self):
         return

--- a/plugin.py
+++ b/plugin.py
@@ -52,7 +52,7 @@ class BasePlugin:
     maxAttempts = 3
     httpTimeout = 3
 
-    zappi_mode_texts = { 1: 'Fast', 2: 'Eco', 3: 'Eco++' }
+    zappi_mode_texts = { 1: 'Fast', 2: 'Eco', 3: 'Eco++', 4: 'Stop' }
     zappi_status_texts = { 1 : 'Waiting for export', 2 : 'DSR-Demand Side Response', 3: 'Diverting/Charging', 4: 'Boosting', 5: 'Charge Complete' }
     charge_status_texts = { 'A' : 'EV disconnected', 'B1': 'EV connected', 'B2' : 'Waiting for EV', 'C1': 'EV ready to charge', 'C2': 'Charging', 'F': 'Fault / Restart' }
     # Source - https://myenergi.info/open-energy-monitor-local-emoncms-t2192.html
@@ -150,6 +150,7 @@ class BasePlugin:
                     zappi_zmo = 0                                   # Zappi Mode
                     zappi_sta = 0                                   # Zappi Status
                     zappi_pst = ''                                  # Charge Status
+                    zappi_che_watt = 0                              # Charge added this session
 
                     for data in j:
 
@@ -178,6 +179,8 @@ class BasePlugin:
                                     zappi_sta = device['sta']
                                 if 'pst' in device:
                                     zappi_pst = device['pst']
+                                if 'che' in device:
+                                    zappi_che_watt += device['che']
 
                             zappi_hom_watt = (grid_pwr + zappi_gen_watt) - (zappi_div_watt + zappi_gep_watt)
                             zappi_slf_watt = max(zappi_gen_watt - zappi_gep_watt + min(grid_pwr, 0), 0)
@@ -205,6 +208,7 @@ class BasePlugin:
                     Devices[8].Update(nValue=0, sValue=zappi_zmo_text)
                     Devices[9].Update(nValue=0, sValue=zappi_sta_text)
                     Devices[10].Update(nValue=0, sValue=zappi_pst_text)
+                    #Devices[11].Update(nValue=0, sValue=str(zappi_che_watt)+";0")  # TODO
 
                     break # while True
 


### PR DESCRIPTION
I have added three (text) devices that show the Zappi Mode, Zappi Status and Charge Status. The status is interpreted from the same json that is already fetched from the myEnergi API so no extra calls necessary. 

Known limitations: if you have multiple Zappis this is less useful, as it only displays status for the last Zappi in the setup. Works great on my simple home setup with a single Zappi though (as I made it for personal use at first), but thought it might make a useful addition for your plugin if you like.